### PR TITLE
Loosen faraday requirement to v1.x from v1.0.x

### DIFF
--- a/.github/workflows/gem-push.yml
+++ b/.github/workflows/gem-push.yml
@@ -16,10 +16,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
-    - name: Set up Ruby 2.6
-      uses: actions/setup-ruby@v1
+    - name: Set up Ruby 3.3
+      uses: ruby/setup-ruby@v1
       with:
-        ruby-version: 2.6.x
+        ruby-version: 3.3.0
 
     - name: Publish to RubyGems
       run: |

--- a/.github/workflows/gem-push.yml
+++ b/.github/workflows/gem-push.yml
@@ -3,8 +3,8 @@ name: Ruby Gem
 on:
   push:
     branches: [ "main" ]
-  pull_request:
-    branches: [ "main" ]
+  # pull_request:
+  #   branches: [ "main" ]
 
 jobs:
   build:

--- a/.github/workflows/specs.yml
+++ b/.github/workflows/specs.yml
@@ -19,15 +19,14 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby-version: ['2.6', '2.7', '3.0']
+        ruby-version: ['3.0', '3.1', '3.2', '3.3']
 
     steps:
     - uses: actions/checkout@v2
     - name: Set up Ruby
     # To automatically get bug fixes and new Ruby versions for ruby/setup-ruby,
     # change this to (see https://github.com/ruby/setup-ruby#versioning):
-    # uses: ruby/setup-ruby@v1
-      uses: ruby/setup-ruby@473e4d8fe5dd94ee328fdfca9f8c9c7afc9dae5e
+      uses: ruby/setup-ruby@v1
       with:
         ruby-version: ${{ matrix.ruby-version }}
         bundler-cache: true # runs 'bundle install' and caches installed gems automatically

--- a/lib/loogi_http/version.rb
+++ b/lib/loogi_http/version.rb
@@ -1,3 +1,3 @@
 module LoogiHttp
-  VERSION = '1.0.0'.freeze
+  VERSION = '2.0.0'.freeze
 end

--- a/loogi_http.gemspec
+++ b/loogi_http.gemspec
@@ -33,7 +33,7 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency 'bundler', '>= 2.0'
   spec.add_development_dependency 'byebug', '~> 11.0'
-  spec.add_development_dependency 'rake', '~> 10.0'
+  spec.add_development_dependency 'rake', '>= 12.3.3'
   spec.add_development_dependency 'rspec', '~> 3.0'
   spec.add_development_dependency 'webmock', '~> 3.5.1'
 end

--- a/loogi_http.gemspec
+++ b/loogi_http.gemspec
@@ -27,12 +27,12 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'faraday', '~> 1.0.1'
+  spec.add_dependency 'faraday', '~> 1.0'
   spec.add_dependency 'faraday-cookie_jar', '~> 0.0.6'
   spec.add_dependency 'faraday_middleware', '~> 1.0.0'
 
   spec.add_development_dependency 'bundler', '>= 2.0'
-  spec.add_development_dependency 'byebug', '~> 10.0.2'
+  spec.add_development_dependency 'byebug', '~> 11.0'
   spec.add_development_dependency 'rake', '~> 10.0'
   spec.add_development_dependency 'rspec', '~> 3.0'
   spec.add_development_dependency 'webmock', '~> 3.5.1'

--- a/loogi_http.gemspec
+++ b/loogi_http.gemspec
@@ -3,7 +3,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'loogi_http/version'
 
 Gem::Specification.new do |spec|
-  spec.required_ruby_version = '>= 2.6'
+  spec.required_ruby_version = '>= 3.0'
   spec.name          = 'loogi_http'
   spec.version       = LoogiHttp::VERSION
   spec.authors       = ['Juul Labs, Inc.']

--- a/loogi_http.gemspec
+++ b/loogi_http.gemspec
@@ -35,5 +35,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'byebug', '~> 11.0'
   spec.add_development_dependency 'rake', '>= 12.3.3'
   spec.add_development_dependency 'rspec', '~> 3.0'
-  spec.add_development_dependency 'webmock', '~> 3.5.1'
+  spec.add_development_dependency 'webmock', '~> 3.5'
 end

--- a/loogi_http.gemspec
+++ b/loogi_http.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'faraday', '~> 1.0'
   spec.add_dependency 'faraday-cookie_jar', '~> 0.0.6'
-  spec.add_dependency 'faraday_middleware', '~> 1.0.0'
+  spec.add_dependency 'faraday_middleware', '~> 1.0'
 
   spec.add_development_dependency 'bundler', '>= 2.0'
   spec.add_development_dependency 'byebug', '~> 11.0'


### PR DESCRIPTION
We need to update faraday in order to use
the latest version of splitclient-rb so we need to loosen the requirement in loogi_http first.

Also updates byebug to v11 for Ruby v3.3 support.